### PR TITLE
프로젝트 페이지 재디자인

### DIFF
--- a/src/main/java/kr/ac/dankook/group5/azit/project/ProjectController.java
+++ b/src/main/java/kr/ac/dankook/group5/azit/project/ProjectController.java
@@ -32,6 +32,30 @@ public class ProjectController {
             Authentication authentication,
             @PathVariable Long projectId,
             Model model) {
+        return detailPage(authentication, projectId, "overview", "project_detail", model);
+    }
+
+    @GetMapping("/project/{projectId}/{page}")
+    public String detailByPage(
+            Authentication authentication,
+            @PathVariable Long projectId,
+            @PathVariable String page,
+            Model model) {
+        return switch (page) {
+            case "task" -> detailPage(authentication, projectId, page, "project_task", model);
+            case "schedule" -> detailPage(authentication, projectId, page, "project_schedule", model);
+            case "member" -> detailPage(authentication, projectId, page, "project_member", model);
+            case "settings" -> detailPage(authentication, projectId, page, "project_settings", model);
+            default -> "redirect:/project/" + projectId;
+        };
+    }
+
+    private String detailPage(
+            Authentication authentication,
+            Long projectId,
+            String activeProjectPage,
+            String templateName,
+            Model model) {
         String email = authentication.getName();
 
         Project project = projectService.getProjectForMember(email, projectId);
@@ -47,8 +71,9 @@ public class ProjectController {
         model.addAttribute("projectStatuses", ProjectStatus.values());
         model.addAttribute("projectEditable", project.getStatus() == ProjectStatus.IN_PROGRESS);
         model.addAttribute("incompleteTaskCount", tasks.stream().filter(task -> !task.isCompleted()).count());
+        model.addAttribute("activeProjectPage", activeProjectPage);
 
-        return "project_detail";
+        return templateName;
     }
 
     @PostMapping("/project/{projectId}/links")
@@ -64,7 +89,7 @@ public class ProjectController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
-        return "redirect:/project/" + projectId;
+        return "redirect:/project/" + projectId + "/settings";
     }
 
     @PostMapping("/project/{projectId}/status")
@@ -79,7 +104,7 @@ public class ProjectController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
-        return "redirect:/project/" + projectId;
+        return "redirect:/project/" + projectId + "/settings";
     }
 
     @PostMapping("/project/{projectId}/members")
@@ -94,7 +119,7 @@ public class ProjectController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
-        return "redirect:/project/" + projectId;
+        return "redirect:/project/" + projectId + "/member";
     }
 
     @PostMapping("/project/{projectId}/tasks")
@@ -110,7 +135,7 @@ public class ProjectController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
-        return "redirect:/project/" + projectId;
+        return "redirect:/project/" + projectId + "/task";
     }
 
     @PostMapping("/project/{projectId}/tasks/{taskId}/toggle")
@@ -124,7 +149,7 @@ public class ProjectController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
-        return "redirect:/project/" + projectId;
+        return "redirect:/project/" + projectId + "/task";
     }
 
     @PostMapping("/project/{projectId}/invitations")
@@ -139,7 +164,7 @@ public class ProjectController {
         } catch (IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
-        return "redirect:/project/" + projectId;
+        return "redirect:/project/" + projectId + "/member";
     }
 
     @GetMapping("/invitations")

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -194,7 +194,7 @@ ol {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	gap: var(--space-3xs);
+	gap: var(--space-2xs);
 	padding: var(--space-2xs) var(--space-sm);
 	border-radius: var(--radius-sm);
 	font-size: var(--font-size-md\+);

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -1,4 +1,5 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+@import url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/font/lucide.css');
 
 /* ============================================================
    Design Tokens
@@ -438,6 +439,77 @@ ol {
 }
 
 /* ============================================================
+   Icons
+   ============================================================ */
+
+.icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	color: currentColor;
+	font-size: 16px;
+	font-style: normal;
+	font-weight: var(--font-weight-regular);
+	line-height: normal;
+}
+
+/* ============================================================
+   Tabs
+   ============================================================ */
+
+.tabs {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: var(--space-sm);
+	min-height: 42px;
+	border-bottom: var(--stroke-thin) solid var(--color-border);
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.tabs::-webkit-scrollbar {
+	display: none;
+}
+
+.tab {
+	position: relative;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	align-self: stretch;
+	gap: var(--space-2xs);
+	padding: 0 var(--space-xs) var(--space-2xs);
+	border: 0;
+	background: transparent;
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+	white-space: nowrap;
+	cursor: pointer;
+}
+
+.tab.active {
+	color: var(--color-primary);
+}
+
+.tab:hover {
+	color: var(--color-primary);
+}
+
+.tab.active::after {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	height: var(--stroke-thick);
+	border-radius: var(--radius-full);
+	background: var(--color-primary);
+	content: '';
+}
+
+/* ============================================================
    Typography Utilities
    ============================================================ */
 
@@ -588,12 +660,5 @@ ol {
 }
 
 .modal-close-icon {
-	display: block;
-	width: 16px;
-	height: 16px;
-	background-color: currentColor;
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/x.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/x.svg')
-		no-repeat center / contain;
+	font-size: 16px;
 }

--- a/src/main/resources/static/css/profile.css
+++ b/src/main/resources/static/css/profile.css
@@ -1,67 +1,7 @@
 /* ============================================================
    Profile Page — page-specific styles
    Uses common.css design tokens exclusively; no azit.css / bootstrap
-   Icons: lucide-static via CSS mask (no inline SVG)
-   https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/<name>.svg
    ============================================================ */
-
-/* ── Lucide icon base ── */
-.icon {
-	display: inline-block;
-	width: 15px;
-	height: 15px;
-	background-color: currentColor;
-	flex-shrink: 0;
-}
-
-.icon-mail {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/mail.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/mail.svg')
-		no-repeat center / contain;
-}
-
-.icon-user {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/user.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/user.svg')
-		no-repeat center / contain;
-}
-
-.icon-pencil {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/pencil.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/pencil.svg')
-		no-repeat center / contain;
-}
-
-.icon-code-2 {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/code-2.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/code-2.svg')
-		no-repeat center / contain;
-}
-
-.icon-folder {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/folder.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/folder.svg')
-		no-repeat center / contain;
-}
-
-.icon-calendar {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
-		no-repeat center / contain;
-}
-
-.icon-square-pen {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/square-pen.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/square-pen.svg')
-		no-repeat center / contain;
-}
 
 .profile-page {
 	max-width: 1100px;
@@ -231,8 +171,7 @@
 }
 
 .career-icon .icon {
-	width: 20px;
-	height: 20px;
+	font-size: 20px;
 	color: var(--color-primary);
 }
 

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -17,7 +17,7 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--space-xl);
-	padding: var(--space-2xl) 0 var(--space-sm);
+	padding: var(--space-md) 0 var(--space-sm);
 }
 
 .project-detail-identity {

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -1,0 +1,889 @@
+/* ============================================================
+   Project Page
+   Uses common.css design tokens exclusively; no azit.css
+   Icons: lucide-static via CSS mask
+   ============================================================ */
+
+.project-detail-page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xl);
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+.project-detail-hero {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-xl);
+	padding: var(--space-2xl) 0 var(--space-sm);
+}
+
+.project-detail-identity {
+	display: flex;
+	align-items: center;
+	gap: var(--space-md);
+	min-width: 0;
+}
+
+.project-detail-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 72px;
+	height: 72px;
+	border: var(--stroke-thin) solid var(--color-border);
+	border-radius: var(--radius-lg);
+	background: var(--color-surface);
+	color: var(--color-primary);
+	font-size: var(--font-size-5xl);
+	font-weight: var(--font-weight-extrabold);
+	flex: 0 0 auto;
+	box-shadow: var(--shadow-sm);
+}
+
+.project-detail-title-group {
+	min-width: 0;
+}
+
+.project-detail-title-row {
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	flex-wrap: wrap;
+}
+
+.project-detail-title-row h1 {
+	color: var(--color-text);
+	font-size: var(--font-size-9xl);
+	font-weight: var(--font-weight-extrabold);
+	letter-spacing: var(--letter-spacing-tight-md);
+	line-height: 1.2;
+}
+
+.project-detail-title-group p {
+	margin-top: var(--space-3xs);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-lg);
+	line-height: 1.5;
+}
+
+.project-detail-meta {
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	margin-top: var(--space-xs);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md);
+}
+
+.project-detail-meta strong {
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md);
+	font-weight: var(--font-weight-semibold);
+}
+
+.project-detail-meta-divider {
+	width: var(--stroke-thin);
+	height: 18px;
+	background: var(--color-border);
+}
+
+.project-detail-avatar-stack {
+	display: flex;
+}
+
+.project-detail-avatar-stack span {
+	width: 24px;
+	height: 24px;
+	margin-left: -6px;
+	border: var(--stroke-thin) solid var(--color-surface);
+	border-radius: var(--radius-full);
+	background: var(--color-primary);
+}
+
+.project-detail-avatar-stack span:first-child {
+	margin-left: 0;
+}
+
+.project-detail-avatar-stack span:nth-child(2) {
+	background: var(--color-accent-blue-mid);
+}
+
+.project-detail-avatar-stack span:nth-child(3) {
+	background: var(--color-accent-green);
+}
+
+.project-detail-status {
+	display: inline-flex;
+	align-items: center;
+	padding: var(--space-3xs) var(--space-xs);
+	border-radius: var(--radius-full);
+	background: var(--chip-indigo);
+	color: var(--color-primary);
+	font-size: var(--font-size-md);
+	font-weight: var(--font-weight-bold);
+	line-height: 1.2;
+}
+
+.project-detail-status.completed {
+	background: var(--chip-green);
+	color: var(--color-accent-green-dark);
+}
+
+.project-detail-status.paused {
+	background: var(--color-surface-muted);
+	color: var(--color-text-muted);
+}
+
+.project-detail-hero-actions {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: var(--space-xs);
+	flex-wrap: wrap;
+	flex: 0 0 auto;
+}
+
+.project-detail-link-button {
+	height: 42px;
+	background: var(--color-surface);
+}
+
+.project-detail-icon-link,
+.project-detail-review-icon,
+.project-detail-tab-icon {
+	display: inline-block;
+	background-color: currentColor;
+	flex: 0 0 auto;
+}
+
+.project-detail-icon-link {
+	width: 16px;
+	height: 16px;
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/external-link.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/external-link.svg')
+		no-repeat center / contain;
+}
+
+.project-detail-tabs {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: var(--space-lg);
+	min-height: 42px;
+	border-bottom: var(--stroke-thin) solid var(--color-border);
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.project-detail-tabs::-webkit-scrollbar {
+	display: none;
+}
+
+.project-detail-tab {
+	position: relative;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
+	align-self: stretch;
+	padding: 0 var(--space-xs) var(--space-2xs);
+	border: 0;
+	background: transparent;
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+	white-space: nowrap;
+	cursor: pointer;
+}
+
+.project-detail-tab.active {
+	color: var(--color-primary);
+}
+
+.project-detail-tab:hover {
+	color: var(--color-primary);
+}
+
+.project-detail-tab.active::after {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	height: var(--stroke-thick);
+	border-radius: var(--radius-full);
+	background: var(--color-primary);
+	content: '';
+}
+
+.project-detail-tab-icon {
+	width: 17px;
+	height: 17px;
+}
+
+.icon-home {
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/home.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/home.svg')
+		no-repeat center / contain;
+}
+
+.icon-check {
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/check-square.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/check-square.svg')
+		no-repeat center / contain;
+}
+
+.icon-calendar {
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
+		no-repeat center / contain;
+}
+
+.icon-users {
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/users.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/users.svg')
+		no-repeat center / contain;
+}
+
+.icon-settings {
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/settings.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/settings.svg')
+		no-repeat center / contain;
+}
+
+.project-detail-alerts {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+}
+
+.project-detail-alert {
+	padding: var(--space-xs) var(--space-md);
+	border-radius: var(--radius-sm);
+	font-size: var(--font-size-md);
+	font-weight: var(--font-weight-medium);
+}
+
+.project-detail-alert.error {
+	border: var(--stroke-thin) solid var(--color-accent-red-light);
+	background: var(--chip-red);
+	color: var(--color-accent-red);
+}
+
+.project-detail-alert.success {
+	border: var(--stroke-thin) solid var(--color-border-green);
+	background: var(--chip-green);
+	color: var(--color-accent-green-dark);
+}
+
+.project-detail-layout {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) clamp(300px, 30vw, 380px);
+	gap: var(--space-xl);
+	align-items: start;
+}
+
+.project-detail-panel {
+	display: none;
+}
+
+.project-detail-panel.active {
+	display: block;
+}
+
+.project-detail-main,
+.project-detail-side {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
+	min-width: 0;
+}
+
+.project-detail-card {
+	padding: var(--space-xl);
+	border-color: rgba(229, 231, 235, 0.86);
+	box-shadow: 0 12px 30px var(--overlay-black-5);
+}
+
+.project-detail-settings-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: var(--space-lg);
+	align-items: start;
+}
+
+.project-detail-card-heading {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--space-md);
+	margin-bottom: var(--space-md);
+}
+
+.project-detail-card-heading h2 {
+	color: var(--color-text);
+	font-size: var(--font-size-xl\+);
+	font-weight: var(--font-weight-extrabold);
+	line-height: 1.35;
+}
+
+.project-detail-card-heading p {
+	margin-top: var(--space-3xs);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md);
+}
+
+.project-detail-review-chip {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2xs);
+	min-width: 128px;
+	padding: var(--space-2xs) var(--space-xs);
+	border-radius: var(--radius-md);
+	background: var(--chip-violet);
+	color: var(--color-primary);
+}
+
+.project-detail-review-icon {
+	width: 18px;
+	height: 18px;
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/clock-3.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/clock-3.svg')
+		no-repeat center / contain;
+}
+
+.project-detail-review-chip strong,
+.project-detail-review-chip span {
+	display: block;
+	line-height: 1.25;
+}
+
+.project-detail-review-chip strong {
+	color: var(--color-text);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+}
+
+.project-detail-review-chip span {
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm\+);
+}
+
+.project-detail-progress-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-md);
+}
+
+.project-detail-progress-row {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+}
+
+.project-detail-progress-label {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-xs);
+}
+
+.project-detail-progress-label strong,
+.project-detail-progress-label span {
+	font-size: var(--font-size-lg\+);
+	font-weight: var(--font-weight-bold);
+}
+
+.project-detail-progress-label span {
+	color: var(--color-text);
+}
+
+.project-detail-active-count {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md);
+	font-weight: var(--font-weight-medium);
+	white-space: nowrap;
+}
+
+.project-detail-active-count span:first-child {
+	width: 8px;
+	height: 8px;
+	border-radius: var(--radius-full);
+	background: var(--color-accent-green);
+}
+
+.project-detail-task-form,
+.project-detail-form {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+}
+
+.project-detail-task-form {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(160px, 220px) auto;
+	margin-bottom: var(--space-md);
+	padding: var(--space-xs);
+	border: var(--stroke-thin) solid var(--color-border);
+	border-radius: var(--radius-md);
+	background: var(--color-surface-muted);
+}
+
+.project-detail-form {
+	margin-top: var(--space-sm);
+}
+
+.project-detail-form.compact {
+	margin-top: var(--space-xs);
+}
+
+.project-detail-task-board {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--space-sm);
+}
+
+.project-detail-overview-board {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--space-sm);
+}
+
+.project-detail-task-lane {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+	min-width: 0;
+}
+
+.project-detail-lane-title {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-xs);
+	padding: var(--space-xs) var(--space-sm);
+	border-radius: var(--radius-sm);
+	background: var(--chip-violet);
+	color: var(--color-text);
+}
+
+.project-detail-task-lane-progress .project-detail-lane-title {
+	background: var(--chip-indigo);
+}
+
+.project-detail-task-lane-done .project-detail-lane-title {
+	background: var(--chip-green);
+}
+
+.project-detail-lane-title strong,
+.project-detail-lane-title span {
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+}
+
+.project-detail-lane-title span {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 28px;
+	height: 28px;
+	border-radius: var(--radius-sm);
+	background: var(--color-surface);
+}
+
+.project-detail-task-card {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--space-xs);
+	min-height: 120px;
+	padding: var(--space-sm);
+	border: var(--stroke-thin) solid var(--color-border);
+	border-radius: var(--radius-md);
+	background: var(--color-surface);
+	box-shadow: 0 8px 20px rgba(17, 24, 39, 0.04);
+}
+
+.project-detail-task-card.compact {
+	min-height: 132px;
+}
+
+.project-detail-task-card.completed {
+	background: var(--color-surface-muted);
+}
+
+.project-detail-task-card.completed .project-detail-task-content strong {
+	color: var(--color-text-muted);
+	text-decoration: line-through;
+	text-decoration-color: var(--color-text-light);
+	text-decoration-thickness: var(--stroke-thick);
+}
+
+.project-detail-task-content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2xs);
+	min-width: 0;
+}
+
+.project-detail-task-content strong {
+	color: var(--color-text);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+	line-height: 1.45;
+}
+
+.project-detail-task-content p,
+.project-detail-empty {
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md);
+	line-height: 1.6;
+}
+
+.project-detail-check-form {
+	margin: 0;
+}
+
+.project-detail-check {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3xs);
+	padding: var(--space-3xs) var(--space-2xs);
+	border: var(--stroke-thin) solid var(--color-border);
+	border-radius: var(--radius-sm);
+	background: var(--color-surface);
+	color: var(--color-text);
+	font-size: var(--font-size-sm\+);
+	font-weight: var(--font-weight-semibold);
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.project-detail-check input {
+	width: 16px;
+	height: 16px;
+	accent-color: var(--color-primary);
+}
+
+.project-detail-check.readonly {
+	cursor: default;
+}
+
+.project-detail-count {
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+	white-space: nowrap;
+}
+
+.project-detail-member-list,
+.project-detail-candidate-list,
+.project-detail-link-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.project-detail-member,
+.project-detail-candidate {
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	padding: var(--space-xs) 0;
+	border-bottom: var(--stroke-thin) solid var(--color-border);
+}
+
+.project-detail-member:last-child,
+.project-detail-candidate:last-child {
+	border-bottom: 0;
+}
+
+.project-detail-member-avatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 44px;
+	height: 44px;
+	border-radius: var(--radius-full);
+	background: var(--color-primary);
+	color: var(--color-surface);
+	font-size: var(--font-size-lg\+);
+	font-weight: var(--font-weight-bold);
+	flex: 0 0 auto;
+}
+
+.project-detail-member:nth-child(2n) .project-detail-member-avatar {
+	background: var(--color-accent-orange);
+}
+
+.project-detail-member:nth-child(3n) .project-detail-member-avatar {
+	background: var(--color-text-muted);
+}
+
+.project-detail-member:nth-child(4n) .project-detail-member-avatar {
+	background: var(--color-accent-blue);
+}
+
+.project-detail-member strong,
+.project-detail-candidate strong {
+	color: var(--color-text);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+}
+
+.project-detail-member p,
+.project-detail-candidate p {
+	color: var(--color-text-light);
+	font-size: var(--font-size-md);
+}
+
+.project-detail-member > div:nth-child(2),
+.project-detail-candidate > div:first-child {
+	min-width: 0;
+	flex: 1;
+}
+
+.project-detail-member-menu {
+	width: 18px;
+	height: 18px;
+	background-color: var(--color-text-light);
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/more-horizontal.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/more-horizontal.svg')
+		no-repeat center / contain;
+}
+
+.project-detail-wide-button {
+	width: 100%;
+	margin-top: var(--space-sm);
+}
+
+.project-detail-wide-button.no-margin {
+	margin-top: 0;
+}
+
+.project-detail-invite-panel {
+	margin-top: var(--space-sm);
+	padding-top: var(--space-sm);
+	border-top: var(--stroke-thin) solid var(--color-border);
+}
+
+.project-detail-rhythm-card {
+	overflow: hidden;
+}
+
+.project-detail-rhythm-card .project-detail-card-heading {
+	align-items: center;
+}
+
+.project-detail-bolt {
+	width: 20px;
+	height: 20px;
+	background: var(--color-accent-orange);
+	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/zap.svg')
+		no-repeat center / contain;
+	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/zap.svg') no-repeat
+		center / contain;
+	flex: 0 0 auto;
+}
+
+.project-detail-rhythm-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: var(--space-2xs);
+}
+
+.project-detail-rhythm-grid.large {
+	grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.project-detail-rhythm-grid span {
+	aspect-ratio: 1.6 / 1;
+	border-radius: var(--radius-sm);
+	background: var(--chip-orange);
+}
+
+.project-detail-rhythm-grid span.muted {
+	background: var(--color-surface-muted);
+}
+
+.project-detail-rhythm-grid span.active {
+	background: var(--color-primary);
+	box-shadow: inset 0 0 0 var(--stroke-thin) rgba(255, 255, 255, 0.28);
+}
+
+.project-detail-rhythm-summary {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--space-3xs);
+	margin-top: var(--space-sm);
+	padding: var(--space-xs);
+	border-radius: var(--radius-sm);
+	background: var(--chip-violet);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-md\+);
+}
+
+.project-detail-rhythm-summary strong {
+	color: var(--color-text);
+	font-weight: var(--font-weight-extrabold);
+}
+
+.project-detail-link-row {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--space-xs);
+	min-width: 0;
+	padding: var(--space-xs) 0;
+	border-bottom: var(--stroke-thin) solid var(--color-border);
+	color: var(--color-text);
+}
+
+.project-detail-link-row:last-child {
+	border-bottom: 0;
+}
+
+.project-detail-link-row .project-detail-icon-link {
+	margin-top: var(--space-3xs);
+	color: var(--color-primary);
+}
+
+.project-detail-link-row > span:nth-child(2) {
+	min-width: 0;
+	flex: 1;
+}
+
+.project-detail-link-row strong,
+.project-detail-link-row small {
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.project-detail-link-row strong {
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-bold);
+}
+
+.project-detail-link-row small {
+	color: var(--color-text-muted);
+	font-size: var(--font-size-sm\+);
+}
+
+.project-detail-link-row em {
+	flex: 0 1 auto;
+	max-width: 180px;
+	padding: var(--space-3xs) var(--space-2xs);
+	border-radius: var(--radius-full);
+	background: var(--chip-indigo);
+	color: var(--color-primary);
+	font-size: var(--font-size-sm\+);
+	font-style: normal;
+	font-weight: var(--font-weight-semibold);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+[hidden] {
+	display: none !important;
+}
+
+@media (max-width: 1100px) {
+	.project-detail-page {
+		width: 100%;
+	}
+
+	.project-detail-hero {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.project-detail-hero-actions {
+		justify-content: flex-start;
+		width: 100%;
+	}
+
+	.project-detail-layout {
+		grid-template-columns: 1fr;
+	}
+
+	.project-detail-settings-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 720px) {
+	main {
+		padding: var(--space-md);
+	}
+
+	.project-detail-hero {
+		padding-top: 0;
+	}
+
+	.project-detail-identity {
+		align-items: flex-start;
+	}
+
+	.project-detail-icon {
+		width: 56px;
+		height: 56px;
+		border-radius: var(--radius-md);
+		font-size: var(--font-size-xl\+);
+	}
+
+	.project-detail-title-row h1 {
+		font-size: var(--font-size-5xl);
+	}
+
+	.project-detail-tabs {
+		gap: var(--space-md);
+	}
+
+	.project-detail-card {
+		padding: var(--space-sm);
+	}
+
+	.project-detail-card-heading,
+	.project-detail-progress-label {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.project-detail-task-form,
+	.project-detail-task-board,
+	.project-detail-overview-board {
+		grid-template-columns: 1fr;
+	}
+
+	.project-detail-task-card {
+		min-height: 0;
+	}
+
+	.project-detail-settings-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.project-detail-link-row {
+		flex-wrap: wrap;
+	}
+
+	.project-detail-link-row em {
+		max-width: 100%;
+	}
+}

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -496,6 +496,20 @@
 	gap: var(--space-xs);
 	padding: var(--space-xs) 0;
 	border-bottom: var(--stroke-thin) solid var(--color-border);
+	text-decoration: none;
+}
+
+a.project-detail-member {
+	cursor: pointer;
+	transition: background 0.15s;
+	border-radius: var(--radius-sm);
+	margin: 0 calc(-1 * var(--space-xs));
+	padding-left: var(--space-xs);
+	padding-right: var(--space-xs);
+}
+
+a.project-detail-member:hover {
+	background: var(--color-surface-muted);
 }
 
 .project-detail-member:last-child,
@@ -540,6 +554,11 @@
 .project-detail-candidate p {
 	color: var(--color-text-light);
 	font-size: var(--font-size-md);
+}
+
+.project-detail-member-email {
+	font-size: var(--font-size-sm);
+	color: var(--color-text-muted);
 }
 
 .project-detail-member > div:nth-child(2),

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -210,7 +210,7 @@
 .project-detail-card {
 	padding: var(--space-xl);
 	border-color: rgba(229, 231, 235, 0.86);
-	box-shadow: 0 12px 30px var(--overlay-black-5);
+	box-shadow: var(--shadow-md);
 }
 
 .project-detail-settings-grid {
@@ -429,6 +429,7 @@
 .project-detail-task-content {
 	display: flex;
 	flex-direction: column;
+	align-items: flex-start;
 	gap: var(--space-2xs);
 	min-width: 0;
 }

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -1,7 +1,6 @@
 /* ============================================================
    Project Page
    Uses common.css design tokens exclusively; no azit.css
-   Icons: lucide-static via CSS mask
    ============================================================ */
 
 .project-detail-page {
@@ -151,112 +150,12 @@
 	background: var(--color-surface);
 }
 
-.project-detail-icon-link,
-.project-detail-review-icon,
-.project-detail-tab-icon {
-	display: inline-block;
-	background-color: currentColor;
-	flex: 0 0 auto;
-}
-
 .project-detail-icon-link {
-	width: 16px;
-	height: 16px;
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/external-link.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/external-link.svg')
-		no-repeat center / contain;
+	font-size: 16px;
 }
 
-.project-detail-tabs {
-	position: relative;
-	display: flex;
-	align-items: center;
-	gap: var(--space-lg);
-	min-height: 42px;
-	border-bottom: var(--stroke-thin) solid var(--color-border);
-	overflow-x: auto;
-	scrollbar-width: none;
-}
-
-.project-detail-tabs::-webkit-scrollbar {
-	display: none;
-}
-
-.project-detail-tab {
-	position: relative;
-	z-index: 1;
-	display: inline-flex;
-	align-items: center;
-	gap: var(--space-3xs);
-	align-self: stretch;
-	padding: 0 var(--space-xs) var(--space-2xs);
-	border: 0;
-	background: transparent;
-	color: var(--color-text-muted);
-	font-size: var(--font-size-md\+);
-	font-weight: var(--font-weight-bold);
-	white-space: nowrap;
-	cursor: pointer;
-}
-
-.project-detail-tab.active {
-	color: var(--color-primary);
-}
-
-.project-detail-tab:hover {
-	color: var(--color-primary);
-}
-
-.project-detail-tab.active::after {
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	height: var(--stroke-thick);
-	border-radius: var(--radius-full);
-	background: var(--color-primary);
-	content: '';
-}
-
-.project-detail-tab-icon {
-	width: 17px;
-	height: 17px;
-}
-
-.icon-home {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/home.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/home.svg')
-		no-repeat center / contain;
-}
-
-.icon-check {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/check-square.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/check-square.svg')
-		no-repeat center / contain;
-}
-
-.icon-calendar {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
-		no-repeat center / contain;
-}
-
-.icon-users {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/users.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/users.svg')
-		no-repeat center / contain;
-}
-
-.icon-settings {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/settings.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/settings.svg')
-		no-repeat center / contain;
+.project-tab-icon {
+	font-size: 18px;
 }
 
 .project-detail-alerts {
@@ -353,12 +252,7 @@
 }
 
 .project-detail-review-icon {
-	width: 18px;
-	height: 18px;
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/clock-3.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/clock-3.svg')
-		no-repeat center / contain;
+	font-size: 18px;
 }
 
 .project-detail-review-chip strong,
@@ -655,13 +549,8 @@
 }
 
 .project-detail-member-menu {
-	width: 18px;
-	height: 18px;
-	background-color: var(--color-text-light);
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/more-horizontal.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/more-horizontal.svg')
-		no-repeat center / contain;
+	font-size: 18px;
+	color: var(--color-text-light);
 }
 
 .project-detail-wide-button {
@@ -688,13 +577,8 @@
 }
 
 .project-detail-bolt {
-	width: 20px;
-	height: 20px;
-	background: var(--color-accent-orange);
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/zap.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/zap.svg') no-repeat
-		center / contain;
+	font-size: 20px;
+	color: var(--color-accent-orange);
 	flex: 0 0 auto;
 }
 
@@ -851,7 +735,7 @@
 		font-size: var(--font-size-5xl);
 	}
 
-	.project-detail-tabs {
+	.tabs {
 		gap: var(--space-md);
 	}
 

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -148,6 +148,7 @@
 .project-detail-link-button {
 	height: 42px;
 	background: var(--color-surface);
+	box-shadow: var(--shadow-sm);
 }
 
 .project-detail-icon-link {

--- a/src/main/resources/static/css/project.css
+++ b/src/main/resources/static/css/project.css
@@ -196,7 +196,9 @@
 }
 
 .project-detail-panel.active {
-	display: block;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-lg);
 }
 
 .project-detail-main,

--- a/src/main/resources/static/css/schedule.css
+++ b/src/main/resources/static/css/schedule.css
@@ -144,37 +144,7 @@
 }
 
 .schedule-icon {
-	width: 16px;
-	height: 16px;
-	background-color: currentColor;
-}
-
-.schedule-icon-chevron-left {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/chevron-left.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/chevron-left.svg')
-		no-repeat center / contain;
-}
-
-.schedule-icon-chevron-right {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/chevron-right.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/chevron-right.svg')
-		no-repeat center / contain;
-}
-
-.schedule-icon-plus {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/plus.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/plus.svg')
-		no-repeat center / contain;
-}
-
-.schedule-icon-x {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/x.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/x.svg') no-repeat
-		center / contain;
+	font-size: 16px;
 }
 
 .schedule-scroll {

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -1,7 +1,5 @@
 /* ============================================================
    Sidebar Layout
-   Icons: lucide-static via CSS mask (no inline SVG)
-   https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/<name>.svg
    ============================================================ */
 
 #sidebar {
@@ -44,16 +42,10 @@
 
 #sidebar-notification {
 	display: block;
-	width: 22px;
-	height: 22px;
+	font-size: 20px;
 	color: var(--color-text-muted);
 	cursor: pointer;
 	flex-shrink: 0;
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/bell.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/bell.svg')
-		no-repeat center / contain;
-	background-color: currentColor;
 	transition: color 0.15s;
 }
 
@@ -97,40 +89,9 @@
 	font-weight: var(--font-weight-semibold);
 }
 
-/* ── 아이콘 공통 ── */
 .sidebar-page-icon {
-	width: 20px;
-	height: 20px;
+	font-size: 20px;
 	flex-shrink: 0;
-	background-color: currentColor;
-}
-
-#sidebar-dashboard .sidebar-page-icon {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/layout-dashboard.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/layout-dashboard.svg')
-		no-repeat center / contain;
-}
-
-#sidebar-start .sidebar-page-icon {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/circle-plus.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/circle-plus.svg')
-		no-repeat center / contain;
-}
-
-#sidebar-task .sidebar-page-icon {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/check-square.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/check-square.svg')
-		no-repeat center / contain;
-}
-
-#sidebar-schedule .sidebar-page-icon {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/calendar.svg')
-		no-repeat center / contain;
 }
 
 /* ============================================================
@@ -153,17 +114,9 @@
 	padding: 0 var(--space-xs) var(--space-10);
 }
 
-/* + 아이콘 — h2 ::after 로 표시 */
-#sidebar-projects > h2::after {
-	content: '';
-	display: block;
-	width: 16px;
-	height: 16px;
-	background-color: var(--color-text-muted);
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/plus.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/plus.svg')
-		no-repeat center / contain;
+#sidebar-projects > h2 .icon {
+	font-size: 16px;
+	color: var(--color-text-muted);
 	cursor: pointer;
 	flex-shrink: 0;
 }
@@ -278,15 +231,9 @@
 
 /* label이 시각적 토글 버튼 */
 #sidebar-usermenu-toggle-button {
-	width: 18px;
-	height: 18px;
+	font-size: 18px;
 	flex-shrink: 0;
 	color: var(--color-text-muted);
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/chevron-down.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/chevron-down.svg')
-		no-repeat center / contain;
-	background-color: currentColor;
 	transition:
 		color 0.15s,
 		rotate 0.2s;
@@ -365,24 +312,8 @@
 
 #sidebar-register .sidebar-usermenu-icon,
 #sidebar-logout .sidebar-usermenu-icon {
-	width: 16px;
-	height: 16px;
+	font-size: 16px;
 	flex-shrink: 0;
-	background-color: currentColor;
-}
-
-#sidebar-register .sidebar-usermenu-icon {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/user-plus.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/user-plus.svg')
-		no-repeat center / contain;
-}
-
-#sidebar-logout .sidebar-usermenu-icon {
-	-webkit-mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/log-out.svg')
-		no-repeat center / contain;
-	mask: url('https://cdn.jsdelivr.net/npm/lucide-static@1.17.0/icons/log-out.svg')
-		no-repeat center / contain;
 }
 
 .sidebar-usermenu-label {

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -151,13 +151,20 @@
 }
 
 .sidebar-project-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 32px;
 	height: 32px;
+	border: var(--stroke-thin) solid var(--color-border);
 	border-radius: var(--radius-sm);
-	background: var(--chip-indigo);
+	background: var(--color-surface);
+	color: var(--color-primary);
+	font-size: var(--font-size-md\+);
+	font-weight: var(--font-weight-extrabold);
 	flex-shrink: 0;
 	overflow: hidden;
-	/* 서버에서 이미지/이모지로 채워짐 */
+	box-shadow: var(--shadow-sm);
 }
 
 .sidebar-project-name {

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -25,7 +25,7 @@
 				onclick="this.closest('dialog').close()"
 				aria-label="닫기"
 			>
-				<span class="modal-close-icon"></span>
+				<span class="modal-close-icon icon icon-x"></span>
 			</button>
 
 			<section

--- a/src/main/resources/templates/fragments/project_icon.html
+++ b/src/main/resources/templates/fragments/project_icon.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+	<body>
+		<div
+			th:fragment="projectIcon(title, className)"
+			th:class="${className}"
+			aria-hidden="true"
+		>
+			<span th:text="${#strings.substring(title, 0, 1)}">A</span>
+		</div>
+	</body>
+</html>

--- a/src/main/resources/templates/fragments/project_layout.html
+++ b/src/main/resources/templates/fragments/project_layout.html
@@ -38,64 +38,52 @@
 					target="_blank"
 					rel="noopener"
 				>
-					<span class="project-detail-icon-link" aria-hidden="true"></span>
+					<span class="project-detail-icon-link icon icon-external-link" aria-hidden="true"></span>
 					<span th:text="${link.label}">GitHub 저장소</span>
 				</a>
 			</div>
 		</section>
 
-		<nav class="project-detail-tabs" aria-label="프로젝트 상세 메뉴">
+		<nav class="tabs" aria-label="프로젝트 상세 메뉴">
 			<a
-				class="project-detail-tab"
+				class="tab"
 				th:classappend="${activePage == 'overview'} ? ' active'"
 				th:href="@{/project/{projectId}(projectId=${project.id})}"
 			>
-				<span class="project-detail-tab-icon icon-home" aria-hidden="true"></span>
+				<span class="project-tab-icon icon icon-home" aria-hidden="true"></span>
 				개요
 			</a>
 			<a
-				class="project-detail-tab"
+				class="tab"
 				th:classappend="${activePage == 'task'} ? ' active'"
 				th:href="@{/project/{projectId}/task(projectId=${project.id})}"
 			>
-				<span
-					class="project-detail-tab-icon icon-check"
-					aria-hidden="true"
-				></span>
+				<span class="project-tab-icon icon icon-check-square" aria-hidden="true"></span>
 				할 일
 			</a>
 			<a
-				class="project-detail-tab"
+				class="tab"
 				th:classappend="${activePage == 'schedule'} ? ' active'"
 				th:href="@{/project/{projectId}/schedule(projectId=${project.id})}"
 			>
-				<span
-					class="project-detail-tab-icon icon-calendar"
-					aria-hidden="true"
-				></span>
+				<span class="project-tab-icon icon icon-calendar" aria-hidden="true"></span>
 				일정
 			</a>
 			<a
-				class="project-detail-tab"
+				class="tab"
 				th:classappend="${activePage == 'member'} ? ' active'"
 				th:href="@{/project/{projectId}/member(projectId=${project.id})}"
 			>
-				<span
-					class="project-detail-tab-icon icon-users"
-					aria-hidden="true"
-				></span>
+				<span class="project-tab-icon icon icon-users" aria-hidden="true"></span>
 				팀
 			</a>
 			<a
-				class="project-detail-tab"
+				class="tab"
 				th:classappend="${activePage == 'settings'} ? ' active'"
 				th:href="@{/project/{projectId}/settings(projectId=${project.id})}"
 				th:if="${projectOwner}"
 			>
-				<span
-					class="project-detail-tab-icon icon-settings"
-					aria-hidden="true"
-				></span>
+				<span class="project-tab-icon icon icon-settings" aria-hidden="true"></span>
 				설정
 			</a>
 		</nav>

--- a/src/main/resources/templates/fragments/project_layout.html
+++ b/src/main/resources/templates/fragments/project_layout.html
@@ -3,7 +3,7 @@
 	<head th:fragment="head">
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title th:text="${project.title} + ' | AZIT'">Project | AZIT</title>
+		<title th:text="${project.title} + ' - AZIT'">Project | AZIT</title>
 		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 		<link rel="stylesheet" href="/css/common.css" />
 		<link rel="stylesheet" href="/css/sidebar.css" />

--- a/src/main/resources/templates/fragments/project_layout.html
+++ b/src/main/resources/templates/fragments/project_layout.html
@@ -20,9 +20,9 @@
 				<div class="project-detail-title-group">
 					<div class="project-detail-title-row">
 						<h1 th:text="${project.title}">프로젝트 이름</h1>
-						<span class="chip chip-green" th:text="${project.status.label}">
-							진행중
-						</span>
+						<span class="chip chip-green" th:if="${project.status.name() == 'IN_PROGRESS'}" th:text="${project.status.label}">진행중</span>
+						<span class="chip chip-orange" th:if="${project.status.name() == 'COMPLETED'}" th:text="${project.status.label}">완료</span>
+						<span class="chip chip-red" th:if="${project.status.name() == 'PAUSED'}" th:text="${project.status.label}">중단</span>
 					</div>
 					<p th:text="${project.description}">프로젝트 설명</p>
 					<div class="project-detail-meta"></div>

--- a/src/main/resources/templates/fragments/project_layout.html
+++ b/src/main/resources/templates/fragments/project_layout.html
@@ -13,9 +13,9 @@
 	<div th:fragment="header(activePage)">
 		<section class="project-detail-hero">
 			<div class="project-detail-identity">
-				<div class="project-detail-icon" aria-hidden="true">
-					<span th:text="${#strings.substring(project.title, 0, 1)}">A</span>
-				</div>
+				<div
+					th:replace="~{fragments/project_icon :: projectIcon(${project.title}, 'project-detail-icon')}"
+				></div>
 
 				<div class="project-detail-title-group">
 					<div class="project-detail-title-row">

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -42,6 +42,7 @@
 				<div>
 					<a
 						id="sidebar-notification"
+						class="icon icon-bell"
 						th:href="@{/invitations}"
 						aria-label="초대 목록"
 					></a>
@@ -56,7 +57,7 @@
 							th:href="@{/}"
 							th:classappend="${currentPath == '/'} ? 'active'"
 						>
-							<div class="sidebar-page-icon"></div>
+							<div class="sidebar-page-icon icon icon-layout-dashboard"></div>
 							<div class="sidebar-page-name">대시보드</div>
 						</a>
 					</li>
@@ -67,7 +68,7 @@
 							th:href="@{/}"
 							th:classappend="${currentPath == '/'} ? 'active'"
 						>
-							<div class="sidebar-page-icon"></div>
+							<div class="sidebar-page-icon icon icon-circle-plus"></div>
 							<div class="sidebar-page-name">시작하기</div>
 						</a>
 					</li>
@@ -78,7 +79,7 @@
 							th:href="@{/}"
 							th:classappend="${currentPath == '/'} ? 'active'"
 						>
-							<div class="sidebar-page-icon"></div>
+							<div class="sidebar-page-icon icon icon-check-square"></div>
 							<div class="sidebar-page-name">할 일</div>
 						</a>
 					</li>
@@ -89,14 +90,14 @@
 							th:href="@{/schedule}"
 							th:classappend="${currentPath == '/schedule'} ? 'active'"
 						>
-							<div class="sidebar-page-icon"></div>
+							<div class="sidebar-page-icon icon icon-calendar"></div>
 							<div class="sidebar-page-name">일정</div>
 						</a>
 					</li>
 				</ul>
 			</nav>
 			<nav id="sidebar-projects" th:if="${sidebarMemberName != null}">
-				<h2>내 프로젝트</h2>
+				<h2>내 프로젝트 <span class="icon icon-plus" aria-hidden="true"></span></h2>
 				<ul>
 					<li th:each="project: ${sidebarProjects}">
 						<a
@@ -147,7 +148,7 @@
 						/>
 						<label
 							id="sidebar-usermenu-toggle-button"
-							class="toggle-button"
+							class="toggle-button icon icon-chevron-down"
 							for="sidebar-usermenu-toggle-input"
 						></label>
 						<nav id="sidebar-usermenu">
@@ -158,14 +159,14 @@
 										th:href="@{/register}"
 										onclick="authSwitch('register');event.preventDefault();"
 									>
-										<div class="sidebar-usermenu-icon"></div>
+										<div class="sidebar-usermenu-icon icon icon-user-plus"></div>
 										<div class="sidebar-usermenu-label">회원가입</div>
 									</a>
 								</li>
 								<li th:if="${sidebarMemberName != null}">
 									<form th:action="@{/logout}" method="POST">
 										<button id="sidebar-logout" type="submit">
-											<div class="sidebar-usermenu-icon"></div>
+											<div class="sidebar-usermenu-icon icon icon-log-out"></div>
 											<div class="sidebar-usermenu-label">
 												로그아웃
 											</div>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -103,7 +103,7 @@
 						<a
 							class="sidebar-project"
 							th:href="@{/project/{projectId}(projectId=${project.id})}"
-							th:classappend="${currentPath == #strings.concat('/project/', project.id)} ? 'active'"
+							th:classappend="${currentPath == #strings.concat('/project/', project.id) || #strings.startsWith(currentPath, #strings.concat('/project/', project.id, '/'))} ? 'active'"
 						>
 							<div
 								th:replace="~{fragments/project_icon :: projectIcon(${project.title}, 'sidebar-project-icon')}"

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -105,7 +105,9 @@
 							th:href="@{/project/{projectId}(projectId=${project.id})}"
 							th:classappend="${currentPath == #strings.concat('/project/', project.id)} ? 'active'"
 						>
-							<div class="sidebar-project-icon"></div>
+							<div
+								th:replace="~{fragments/project_icon :: projectIcon(${project.title}, 'sidebar-project-icon')}"
+							></div>
 							<div
 								class="sidebar-project-name"
 								th:text="${project.title}"

--- a/src/main/resources/templates/project_detail.html
+++ b/src/main/resources/templates/project_detail.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="~{fragments/project_layout :: head}"></head>
 
-	<body class="has-sidebar">
+	<body>
 		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
 
 		<main>
@@ -186,12 +186,7 @@
 									th:href="@{/profile/{id}(id=${projectMember.member.id})}"
 									th:each="projectMember : ${project.members}"
 								>
-									<div
-										class="project-detail-member-avatar"
-										th:text="${#strings.substring(projectMember.member.name, 0, 1)}"
-									>
-										김
-									</div>
+									<th:block th:replace="~{fragments/avatar :: avatar(${projectMember.member.profileUrl}, ${projectMember.member.name}, 'project-detail-member-avatar')}"></th:block>
 									<div>
 										<strong th:text="${projectMember.member.name}"
 											>팀원 이름</strong

--- a/src/main/resources/templates/project_detail.html
+++ b/src/main/resources/templates/project_detail.html
@@ -181,8 +181,9 @@
 								class="project-detail-member-list"
 								th:if="${project.members != null and !project.members.isEmpty()}"
 							>
-								<div
+								<a
 									class="project-detail-member"
+									th:href="@{/profile/{id}(id=${projectMember.member.id})}"
 									th:each="projectMember : ${project.members}"
 								>
 									<div
@@ -197,11 +198,7 @@
 										>
 										<p th:text="${projectMember.role}">OWNER</p>
 									</div>
-									<span
-										class="project-detail-member-menu icon icon-more-horizontal"
-										aria-hidden="true"
-									></span>
-								</div>
+								</a>
 							</div>
 							<a
 								class="btn btn-outline project-detail-wide-button"

--- a/src/main/resources/templates/project_detail.html
+++ b/src/main/resources/templates/project_detail.html
@@ -18,7 +18,7 @@
 									<p>모든 완료 진행 상황</p>
 								</div>
 								<!-- <div class="project-detail-review-chip">
-									<span class="project-detail-review-icon" aria-hidden="true"></span>
+									<span class="project-detail-review-icon icon icon-clock-3" aria-hidden="true"></span>
 									<div>
 										<strong th:text="${incompleteTaskCount} + '개 남음'">4개 남음</strong>
 										<span>검토 주기</span>
@@ -138,7 +138,7 @@
 									<h2>만날 수 있는 시간</h2>
 								</div>
 								<span
-									class="project-detail-bolt"
+									class="project-detail-bolt icon icon-zap"
 									aria-hidden="true"
 								></span>
 							</div>
@@ -198,7 +198,7 @@
 										<p th:text="${projectMember.role}">OWNER</p>
 									</div>
 									<span
-										class="project-detail-member-menu"
+										class="project-detail-member-menu icon icon-more-horizontal"
 										aria-hidden="true"
 									></span>
 								</div>

--- a/src/main/resources/templates/project_detail.html
+++ b/src/main/resources/templates/project_detail.html
@@ -1,475 +1,218 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title th:text="${project.title} + ' | Azit'">Project | Azit</title>
-		<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-		<link rel="stylesheet" href="/css/common.css" />
-		<link rel="stylesheet" href="/css/sidebar.css" />
-		<link rel="stylesheet" href="/css/azit.css" />
-	</head>
+	<head th:replace="~{fragments/project_layout :: head}"></head>
 
-	<body class="azit-app has-sidebar">
+	<body class="has-sidebar">
 		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
 
-		<main class="azit-shell azit-page">
-			<section class="azit-page-heading">
-				<div>
-					<div class="azit-kicker">Project Workspace</div>
-					<div
-						style="
-							display: flex;
-							align-items: center;
-							gap: 12px;
-							flex-wrap: wrap;
-						"
-					>
-						<h1 th:text="${project.title}">프로젝트 이름</h1>
-						<span
-							class="azit-status-badge"
-							th:classappend="${project.status.cssClass}"
-							th:text="${project.status.label}"
-						>
-							진행중
-						</span>
-					</div>
-					<p th:text="${project.description}">프로젝트 설명</p>
-				</div>
-				<form
-					th:if="${projectOwner}"
-					th:action="@{/project/{projectId}/status(projectId=${project.id})}"
-					method="post"
-					onsubmit="return confirmProjectStatusChange();"
-					style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap"
-				>
-					<select
-						id="projectStatusSelect"
-						class="azit-input"
-						name="status"
-						required
-					>
-						<option
-							th:each="status : ${projectStatuses}"
-							th:value="${status}"
-							th:text="${status.label}"
-							th:selected="${status == project.status}"
-						>
-							진행중
-						</option>
-					</select>
-					<button type="submit" class="azit-button">상태 변경</button>
-				</form>
-				<form
-					th:if="${projectOwner}"
-					th:action="@{/project/{projectId}/delete(projectId=${project.id})}"
-					method="post"
-					onsubmit="return confirm('프로젝트를 삭제하시겠습니까?');"
-				>
-					<button type="submit" class="azit-button azit-button-danger">
-						프로젝트 삭제
-					</button>
-				</form>
-			</section>
+		<main>
+			<div class="project-detail-page">
+				<div th:replace="~{fragments/project_layout :: header('overview')}"></div>
 
-			<p
-				class="azit-alert"
-				th:if="${errorMessage}"
-				th:text="${errorMessage}"
-				style="margin-bottom: 16px"
-			></p>
-			<p
-				class="azit-alert-success"
-				th:if="${successMessage}"
-				th:text="${successMessage}"
-				style="margin-bottom: 16px"
-			></p>
-			<p
-				class="azit-alert"
-				th:if="${projectEditable == false}"
-				style="margin-bottom: 16px"
-			>
-				완료 또는 중단된 프로젝트는 조회만 가능합니다. 오너가 상태를 진행중으로
-				변경하면 다시 수정할 수 있습니다.
-			</p>
+				<section class="project-detail-layout">
+					<div class="project-detail-main">
+						<article class="card project-detail-card">
+							<div class="project-detail-card-heading">
+								<div>
+									<h2>스프린트 개요</h2>
+									<p>모든 완료 진행 상황</p>
+								</div>
+								<!-- <div class="project-detail-review-chip">
+									<span class="project-detail-review-icon" aria-hidden="true"></span>
+									<div>
+										<strong th:text="${incompleteTaskCount} + '개 남음'">4개 남음</strong>
+										<span>검토 주기</span>
+									</div>
+								</div> -->
+							</div>
 
-			<section class="azit-grid">
-				<div style="display: grid; gap: 24px">
-					<article class="azit-card">
-						<div
-							class="azit-card-header"
-							style="
-								display: flex;
-								justify-content: space-between;
-								align-items: center;
-								gap: 12px;
-							"
-						>
-							<span>팀원 목록</span>
-							<button
-								th:if="${projectOwner and projectEditable}"
-								type="button"
-								class="azit-button azit-button-secondary"
-								onclick="toggleInvitePanel()"
-							>
-								팀원 추가
-							</button>
-						</div>
-
-						<div class="azit-card-body">
-							<div
-								th:if="${projectOwner and projectEditable}"
-								id="invitePanel"
-								class="azit-form-section"
-								style="display: none; margin-bottom: 16px"
-							>
-								<strong>팀원 초대</strong>
-								<div
-									th:if="${inviteCandidates != null and !inviteCandidates.isEmpty()}"
-									style="display: grid; gap: 10px; margin-top: 12px"
-								>
-									<div
-										class="azit-form-section"
-										th:each="member : ${inviteCandidates}"
-										style="
-											display: flex;
-											justify-content: space-between;
-											align-items: center;
-											gap: 12px;
-										"
-									>
-										<div>
-											<strong th:text="${member.name}"
-												>사용자 이름</strong
-											>
-											<p
-												class="azit-empty"
-												th:text="${member.email}"
-												style="margin-top: 6px"
-											>
-												email@example.com
-											</p>
-										</div>
-
-										<form
-											th:action="@{/project/{projectId}/invitations(projectId=${project.id})}"
-											method="post"
+							<div class="project-detail-progress-list">
+								<div class="project-detail-progress-row">
+									<div class="project-detail-progress-label">
+										<strong>나의 진행도</strong>
+										<span th:text="${myTaskCompletionRate} + '%'"
+											>85%</span
 										>
-											<input
-												type="hidden"
-												name="receiverId"
-												th:value="${member.id}"
-											/>
-											<button
-												type="submit"
-												class="azit-button azit-button-secondary"
-											>
-												초대 보내기
-											</button>
-										</form>
+									</div>
+									<div class="progress">
+										<div
+											class="progress-fill"
+											th:style="'width: ' + ${myTaskCompletionRate} + '%'"
+										></div>
 									</div>
 								</div>
 
-								<p
-									class="azit-empty"
-									th:if="${inviteCandidates == null or inviteCandidates.isEmpty()}"
-									style="margin-top: 10px"
-								>
-									초대할 수 있는 사용자가 없습니다.
-								</p>
-							</div>
-
-							<div
-								th:if="${project.members != null and !project.members.isEmpty()}"
-								style="display: grid; gap: 12px"
-							>
-								<div
-									class="azit-form-section"
-									th:each="projectMember : ${project.members}"
-								>
-									<strong th:text="${projectMember.member.name}"
-										>팀원 이름</strong
-									>
-									<span
-										class="azit-stack-badge"
-										th:text="${projectMember.role}"
-										>OWNER</span
-									>
-									<p
-										class="azit-empty"
-										th:text="${projectMember.member.email}"
-									>
-										email@example.com
-									</p>
-								</div>
-							</div>
-
-							<p
-								class="azit-empty"
-								th:if="${project.members == null or project.members.isEmpty()}"
-							>
-								아직 등록된 팀원이 없습니다.
-							</p>
-						</div>
-					</article>
-
-					<article class="azit-card">
-						<div class="azit-card-header">작업 저장소 링크</div>
-						<div class="azit-card-body">
-							<div
-								th:if="${project.links != null and !project.links.isEmpty()}"
-								style="display: grid; gap: 10px; margin-bottom: 18px"
-							>
-								<a
-									class="azit-form-section"
-									style="display: block"
-									th:each="link : ${project.links}"
-									th:href="${link.url}"
-									target="_blank"
-									rel="noopener"
-								>
-									<strong th:text="${link.label}">GitHub</strong>
-									<p class="azit-empty" th:text="${link.url}">
-										https://github.com
-									</p>
-								</a>
-							</div>
-							<p
-								class="azit-empty"
-								th:if="${project.links == null or project.links.isEmpty()}"
-								style="margin-bottom: 18px"
-							>
-								GitHub, Figma 같은 작업 링크를 추가하세요.
-							</p>
-							<form
-								th:if="${projectEditable}"
-								th:action="@{/project/{id}/links(id=${project.id})}"
-								method="post"
-								style="display: grid; gap: 12px"
-							>
-								<input
-									class="azit-input"
-									type="text"
-									name="label"
-									placeholder="링크 이름: GitHub"
-									required
-								/>
-								<input
-									class="azit-input"
-									type="url"
-									name="url"
-									placeholder="https://github.com/team/repo"
-									required
-								/>
-								<button type="submit" class="azit-button">
-									링크 추가
-								</button>
-							</form>
-						</div>
-					</article>
-
-					<article
-						class="azit-card"
-						th:if="${projectOwner and projectEditable}"
-					>
-						<div class="azit-card-header">이메일로 초대</div>
-						<div class="azit-card-body">
-							<form
-								th:action="@{/project/{projectId}/members(projectId=${project.id})}"
-								method="post"
-								style="display: grid; gap: 12px"
-							>
-								<input
-									type="hidden"
-									th:name="${_csrf.parameterName}"
-									th:value="${_csrf.token}"
-								/>
-								<input
-									class="azit-input"
-									type="email"
-									name="memberEmail"
-									placeholder="초대할 회원 이메일"
-									required
-								/>
-								<button type="submit" class="azit-button">
-									초대 보내기
-								</button>
-							</form>
-							<p
-								class="azit-empty"
-								th:if="${errorMessage}"
-								th:text="${errorMessage}"
-								style="color: #b91c1c; margin-top: 8px"
-							></p>
-						</div>
-					</article>
-				</div>
-
-				<aside class="azit-card">
-					<div class="azit-card-header">태스크 관리</div>
-					<div class="azit-card-body">
-						<div class="azit-form-section" style="margin-bottom: 16px">
-							<strong>나에게 할당된 태스크 완료율</strong>
-
-							<div style="margin-top: 12px">
-								<div
-									style="
-										height: 12px;
-										background: #e5e7eb;
-										border-radius: 999px;
-										overflow: hidden;
-									"
-								>
-									<div
-										style="
-											height: 100%;
-											background: #2563eb;
-											border-radius: 999px;
-										"
-										th:style="'width:' + ${myTaskCompletionRate} + '%; height: 100%; background: #2563eb; border-radius: 999px'"
-									></div>
+								<div class="project-detail-progress-row">
+									<div class="project-detail-progress-label">
+										<strong>팀 평균 진행도</strong>
+										<span th:text="${myTaskCompletionRate} + '%'"
+											>68%</span
+										>
+									</div>
+									<div class="progress">
+										<div
+											class="progress-fill"
+											th:style="'width: ' + ${myTaskCompletionRate} + '%'"
+										></div>
+									</div>
 								</div>
 
-								<p class="azit-empty" style="margin-top: 8px">
-									완료율
-									<strong th:text="${myTaskCompletionRate} + '%'"
-										>0%</strong
-									>
-									<span>
-										/
-										<span th:text="${myCompletedTaskCount}">0</span>
-										개 완료
-									</span>
-								</p>
+								<!-- <div class="project-detail-progress-row">
+									<div class="project-detail-progress-label">
+										<strong>전체 경과 시간</strong>
+										<span th:text="${project.status.label}">진행중</span>
+									</div>
+									<div class="progress">
+										<div
+											class="progress-fill"
+											th:style="'width: ' + ${myTaskCompletionRate} + '%'"
+										></div>
+									</div>
+								</div> -->
 							</div>
-						</div>
+						</article>
 
-						<div class="azit-form-section" style="margin-bottom: 16px">
-							<strong>태스크 추가</strong>
+						<article class="card project-detail-card">
+							<div class="project-detail-card-heading">
+								<h2>현재 스프린트</h2>
+							</div>
 
-							<form
-								th:if="${projectEditable}"
-								th:action="@{/project/{id}/tasks(id=${project.id})}"
-								method="post"
-								style="display: grid; gap: 10px; margin-top: 12px"
-							>
-								<input
-									class="azit-input"
-									type="text"
-									name="title"
-									placeholder="태스크 제목"
-									required
-								/>
-
-								<select class="azit-input" name="assigneeId" required>
-									<option value="">담당자 선택</option>
-									<option
-										th:each="projectMember : ${project.members}"
-										th:value="${projectMember.member.id}"
-										th:text="${projectMember.member.name}"
-									>
-										팀원 이름
-									</option>
-								</select>
-
-								<button type="submit" class="azit-button">
-									태스크 추가
-								</button>
-							</form>
-						</div>
-
-						<div>
-							<strong>태스크 목록</strong>
-
-							<div
-								th:if="${tasks != null and !tasks.isEmpty()}"
-								style="display: grid; gap: 10px; margin-top: 12px"
-							>
+							<div class="project-detail-overview-board">
 								<div
-									class="azit-form-section azit-task-item"
-									th:each="task : ${tasks}"
-									th:classappend="${task.completed} ? ' completed' : ''"
+									class="project-detail-task-lane project-detail-task-lane-progress"
 								>
+									<div class="project-detail-lane-title">
+										<strong>진행 중</strong>
+										<span th:text="${incompleteTaskCount}">1</span>
+									</div>
 									<div
-										style="
-											display: flex;
-											justify-content: space-between;
-											gap: 12px;
-											align-items: center;
-										"
+										class="project-detail-task-card compact"
+										th:each="task : ${tasks}"
+										th:if="${!task.completed}"
 									>
-										<div class="azit-task-content">
+										<div class="project-detail-task-content">
+											<span class="chip chip-purple">진행</span>
 											<strong th:text="${task.title}"
 												>태스크 제목</strong
 											>
-											<p class="azit-empty" style="margin-top: 6px">
-												담당자:
-												<span th:text="${task.assignee.name}"
-													>담당자 이름</span
-												>
+											<p th:text="${task.assignee.name}">
+												담당자 이름
 											</p>
 										</div>
+									</div>
+								</div>
 
-										<form
-											th:if="${projectEditable}"
-											th:action="@{/project/{projectId}/tasks/{taskId}/toggle(projectId=${project.id}, taskId=${task.id})}"
-											method="post"
-											class="azit-task-check-form"
-										>
-											<label class="azit-task-check">
-												<input
-													type="checkbox"
-													th:checked="${task.completed}"
-													onchange="this.form.submit()"
-												/>
-												<span>완료</span>
-											</label>
-										</form>
-										<label
-											th:if="${projectEditable == false}"
-											class="azit-task-check readonly"
-										>
-											<input
-												type="checkbox"
-												th:checked="${task.completed}"
-												disabled
-											/>
-											<span
-												th:text="${task.completed} ? '완료' : '미완료'"
-												>미완료</span
+								<div
+									class="project-detail-task-lane project-detail-task-lane-done"
+								>
+									<div class="project-detail-lane-title">
+										<strong>완료</strong>
+										<span th:text="${myCompletedTaskCount}">4</span>
+									</div>
+									<div
+										class="project-detail-task-card compact completed"
+										th:each="task : ${tasks}"
+										th:if="${task.completed}"
+									>
+										<div class="project-detail-task-content">
+											<span class="chip chip-green">완료됨</span>
+											<strong th:text="${task.title}"
+												>완료한 태스크</strong
 											>
-										</label>
+											<p th:text="${task.assignee.name}">
+												담당자 이름
+											</p>
+										</div>
 									</div>
 								</div>
 							</div>
-
-							<p
-								class="azit-empty"
-								th:if="${tasks == null or tasks.isEmpty()}"
-								style="margin-top: 12px"
-							>
-								아직 등록된 태스크가 없습니다.
-							</p>
-						</div>
+						</article>
 					</div>
-				</aside>
-			</section>
+
+					<aside class="project-detail-side">
+						<article
+							class="card project-detail-card project-detail-availability-card"
+						>
+							<div class="project-detail-card-heading">
+								<div>
+									<h2>만날 수 있는 시간</h2>
+								</div>
+								<span
+									class="project-detail-bolt"
+									aria-hidden="true"
+								></span>
+							</div>
+							<div class="project-detail-rhythm-grid" aria-hidden="true">
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span class="active"></span>
+								<span class="active"></span>
+								<span class="active"></span>
+							</div>
+							<div class="project-detail-rhythm-summary">
+								<span>최적 동기화 시간:</span>
+								<strong>14:30 - 16:00</strong>
+							</div>
+							<a
+								class="btn btn-outline project-detail-wide-button"
+								th:href="@{/project/{projectId}/schedule(projectId=${project.id})}"
+							>
+								일정 확인하기
+							</a>
+						</article>
+
+						<article class="card project-detail-card">
+							<div class="project-detail-card-heading">
+								<h2>팀원</h2>
+								<strong
+									class="project-detail-count"
+									th:text="${project.members != null ? project.members.size() : 0} + '명'"
+									>4명</strong
+								>
+							</div>
+							<div
+								class="project-detail-member-list"
+								th:if="${project.members != null and !project.members.isEmpty()}"
+							>
+								<div
+									class="project-detail-member"
+									th:each="projectMember : ${project.members}"
+								>
+									<div
+										class="project-detail-member-avatar"
+										th:text="${#strings.substring(projectMember.member.name, 0, 1)}"
+									>
+										김
+									</div>
+									<div>
+										<strong th:text="${projectMember.member.name}"
+											>팀원 이름</strong
+										>
+										<p th:text="${projectMember.role}">OWNER</p>
+									</div>
+									<span
+										class="project-detail-member-menu"
+										aria-hidden="true"
+									></span>
+								</div>
+							</div>
+							<a
+								class="btn btn-outline project-detail-wide-button"
+								th:href="@{/project/{projectId}/member(projectId=${project.id})}"
+							>
+								전체 팀원 보기
+							</a>
+						</article>
+					</aside>
+				</section>
+			</div>
 		</main>
-		<script th:inline="javascript">
-			const incompleteTaskCount = Number(/*[[${incompleteTaskCount}]]*/ 0);
-
-			function confirmProjectStatusChange() {
-				const select = document.getElementById('projectStatusSelect');
-				if (select && select.value === 'COMPLETED' && incompleteTaskCount > 0) {
-					return confirm('미완료 태스크가 있습니다. 그래도 완료하시겠습니까?');
-				}
-				return true;
-			}
-
-			function toggleInvitePanel() {
-				const panel = document.getElementById('invitePanel');
-				panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
-			}
-		</script>
 	</body>
 </html>

--- a/src/main/resources/templates/project_member.html
+++ b/src/main/resources/templates/project_member.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="~{fragments/project_layout :: head}"></head>
 
-	<body class="has-sidebar">
+	<body>
 		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
 		<main>
 			<div class="project-detail-page">
@@ -27,12 +27,7 @@
 									th:href="@{/profile/{id}(id=${projectMember.member.id})}"
 									th:each="projectMember : ${project.members}"
 								>
-									<div
-										class="project-detail-member-avatar"
-										th:text="${#strings.substring(projectMember.member.name, 0, 1)}"
-									>
-										김
-									</div>
+									<th:block th:replace="~{fragments/avatar :: avatar(${projectMember.member.profileUrl}, ${projectMember.member.name}, 'project-detail-member-avatar')}"></th:block>
 									<div>
 										<strong th:text="${projectMember.member.name}">팀원 이름</strong>
 										<p th:text="${projectMember.role}">OWNER</p>

--- a/src/main/resources/templates/project_member.html
+++ b/src/main/resources/templates/project_member.html
@@ -36,7 +36,7 @@
 										<strong th:text="${projectMember.member.name}">팀원 이름</strong>
 										<p th:text="${projectMember.role}">OWNER</p>
 									</div>
-									<span class="project-detail-member-menu" aria-hidden="true"></span>
+									<span class="project-detail-member-menu icon icon-more-horizontal" aria-hidden="true"></span>
 								</div>
 							</div>
 							<p

--- a/src/main/resources/templates/project_member.html
+++ b/src/main/resources/templates/project_member.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+	<head th:replace="~{fragments/project_layout :: head}"></head>
+
+	<body class="has-sidebar">
+		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<main>
+			<div class="project-detail-page">
+				<div th:replace="~{fragments/project_layout :: header('member')}"></div>
+				<section class="project-detail-layout">
+					<div class="project-detail-main">
+						<article class="card project-detail-card">
+							<div class="project-detail-card-heading">
+								<h2>팀원</h2>
+								<strong
+									class="project-detail-count"
+									th:text="${project.members != null ? project.members.size() : 0} + '명'"
+									>4명</strong
+								>
+							</div>
+							<div
+								class="project-detail-member-list"
+								th:if="${project.members != null and !project.members.isEmpty()}"
+							>
+								<div
+									class="project-detail-member"
+									th:each="projectMember : ${project.members}"
+								>
+									<div
+										class="project-detail-member-avatar"
+										th:text="${#strings.substring(projectMember.member.name, 0, 1)}"
+									>
+										김
+									</div>
+									<div>
+										<strong th:text="${projectMember.member.name}">팀원 이름</strong>
+										<p th:text="${projectMember.role}">OWNER</p>
+									</div>
+									<span class="project-detail-member-menu" aria-hidden="true"></span>
+								</div>
+							</div>
+							<p
+								class="project-detail-empty"
+								th:if="${project.members == null or project.members.isEmpty()}"
+							>
+								아직 등록된 팀원이 없습니다.
+							</p>
+						</article>
+					</div>
+					<aside class="project-detail-side">
+						<article
+							class="card project-detail-card"
+							th:if="${projectOwner and projectEditable}"
+						>
+							<div class="project-detail-card-heading">
+								<h2>초대 후보</h2>
+							</div>
+							<div
+								class="project-detail-candidate-list"
+								th:if="${inviteCandidates != null and !inviteCandidates.isEmpty()}"
+							>
+								<div
+									class="project-detail-candidate"
+									th:each="member : ${inviteCandidates}"
+								>
+									<div>
+										<strong th:text="${member.name}">사용자 이름</strong>
+										<p th:text="${member.email}">email@example.com</p>
+									</div>
+									<form
+										th:action="@{/project/{projectId}/invitations(projectId=${project.id})}"
+										method="post"
+									>
+										<input type="hidden" name="receiverId" th:value="${member.id}" />
+										<button type="submit" class="btn btn-outline btn-sm">초대</button>
+									</form>
+								</div>
+							</div>
+							<p
+								class="project-detail-empty"
+								th:if="${inviteCandidates == null or inviteCandidates.isEmpty()}"
+							>
+								초대할 수 있는 사용자가 없습니다.
+							</p>
+						</article>
+
+						<article
+							class="card project-detail-card"
+							th:if="${projectOwner and projectEditable}"
+						>
+							<div class="project-detail-card-heading">
+								<h2>이메일로 초대</h2>
+							</div>
+							<form
+								class="project-detail-form"
+								th:action="@{/project/{projectId}/members(projectId=${project.id})}"
+								method="post"
+							>
+								<input
+									type="hidden"
+									th:name="${_csrf.parameterName}"
+									th:value="${_csrf.token}"
+								/>
+								<input
+									class="input"
+									type="email"
+									name="memberEmail"
+									placeholder="초대할 회원 이메일"
+									required
+								/>
+								<button type="submit" class="btn btn-primary">초대 보내기</button>
+							</form>
+						</article>
+					</aside>
+				</section>
+			</div>
+		</main>
+	</body>
+</html>

--- a/src/main/resources/templates/project_member.html
+++ b/src/main/resources/templates/project_member.html
@@ -22,8 +22,9 @@
 								class="project-detail-member-list"
 								th:if="${project.members != null and !project.members.isEmpty()}"
 							>
-								<div
+								<a
 									class="project-detail-member"
+									th:href="@{/profile/{id}(id=${projectMember.member.id})}"
 									th:each="projectMember : ${project.members}"
 								>
 									<div
@@ -35,9 +36,10 @@
 									<div>
 										<strong th:text="${projectMember.member.name}">팀원 이름</strong>
 										<p th:text="${projectMember.role}">OWNER</p>
+										<p th:text="${projectMember.member.email}" class="project-detail-member-email">email@example.com</p>
 									</div>
-									<span class="project-detail-member-menu icon icon-more-horizontal" aria-hidden="true"></span>
-								</div>
+									<!-- <span class="project-detail-member-menu icon icon-more-horizontal" aria-hidden="true"></span> -->
+								</a>
 							</div>
 							<p
 								class="project-detail-empty"
@@ -48,42 +50,6 @@
 						</article>
 					</div>
 					<aside class="project-detail-side">
-						<article
-							class="card project-detail-card"
-							th:if="${projectOwner and projectEditable}"
-						>
-							<div class="project-detail-card-heading">
-								<h2>초대 후보</h2>
-							</div>
-							<div
-								class="project-detail-candidate-list"
-								th:if="${inviteCandidates != null and !inviteCandidates.isEmpty()}"
-							>
-								<div
-									class="project-detail-candidate"
-									th:each="member : ${inviteCandidates}"
-								>
-									<div>
-										<strong th:text="${member.name}">사용자 이름</strong>
-										<p th:text="${member.email}">email@example.com</p>
-									</div>
-									<form
-										th:action="@{/project/{projectId}/invitations(projectId=${project.id})}"
-										method="post"
-									>
-										<input type="hidden" name="receiverId" th:value="${member.id}" />
-										<button type="submit" class="btn btn-outline btn-sm">초대</button>
-									</form>
-								</div>
-							</div>
-							<p
-								class="project-detail-empty"
-								th:if="${inviteCandidates == null or inviteCandidates.isEmpty()}"
-							>
-								초대할 수 있는 사용자가 없습니다.
-							</p>
-						</article>
-
 						<article
 							class="card project-detail-card"
 							th:if="${projectOwner and projectEditable}"

--- a/src/main/resources/templates/project_member.html
+++ b/src/main/resources/templates/project_member.html
@@ -55,7 +55,7 @@
 							th:if="${projectOwner and projectEditable}"
 						>
 							<div class="project-detail-card-heading">
-								<h2>이메일로 초대</h2>
+								<h2>초대</h2>
 							</div>
 							<form
 								class="project-detail-form"

--- a/src/main/resources/templates/project_schedule.html
+++ b/src/main/resources/templates/project_schedule.html
@@ -15,7 +15,7 @@
 									<h2>만날 수 있는 시간</h2>
 									<p>프로젝트 팀 동기화 시간 보기</p>
 								</div>
-								<span class="project-detail-bolt" aria-hidden="true"></span>
+								<span class="project-detail-bolt icon icon-zap" aria-hidden="true"></span>
 							</div>
 							<div class="project-detail-rhythm-grid large" aria-hidden="true">
 								<span></span>

--- a/src/main/resources/templates/project_schedule.html
+++ b/src/main/resources/templates/project_schedule.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+	<head th:replace="~{fragments/project_layout :: head}"></head>
+
+	<body class="has-sidebar">
+		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<main>
+			<div class="project-detail-page">
+				<div th:replace="~{fragments/project_layout :: header('schedule')}"></div>
+				<section class="project-detail-layout">
+					<div class="project-detail-main">
+						<article class="card project-detail-card project-detail-availability-card">
+							<div class="project-detail-card-heading">
+								<div>
+									<h2>만날 수 있는 시간</h2>
+									<p>프로젝트 팀 동기화 시간 보기</p>
+								</div>
+								<span class="project-detail-bolt" aria-hidden="true"></span>
+							</div>
+							<div class="project-detail-rhythm-grid large" aria-hidden="true">
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+								<span class="active"></span>
+								<span class="active"></span>
+								<span class="active"></span>
+							</div>
+							<div class="project-detail-rhythm-summary">
+								<span>최적 동기화 시간:</span>
+								<strong>14:30 - 16:00</strong>
+							</div>
+						</article>
+					</div>
+				</section>
+			</div>
+		</main>
+	</body>
+</html>

--- a/src/main/resources/templates/project_settings.html
+++ b/src/main/resources/templates/project_settings.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="~{fragments/project_layout :: head}"></head>
 
-	<body class="has-sidebar">
+	<body>
 		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
 		<main>
 			<div class="project-detail-page">

--- a/src/main/resources/templates/project_settings.html
+++ b/src/main/resources/templates/project_settings.html
@@ -44,7 +44,7 @@
 							class="project-detail-empty"
 							th:if="${project.links == null or project.links.isEmpty()}"
 						>
-							GitHub, Figma 같은 작업 링크를 추가하세요.
+							작업 링크가 없습니다.
 						</p>
 						<form
 							class="project-detail-form"

--- a/src/main/resources/templates/project_settings.html
+++ b/src/main/resources/templates/project_settings.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+	<head th:replace="~{fragments/project_layout :: head}"></head>
+
+	<body class="has-sidebar">
+		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<main>
+			<div class="project-detail-page">
+				<div th:replace="~{fragments/project_layout :: header('settings')}"></div>
+
+				<section class="project-detail-settings-grid">
+					<article class="card project-detail-card">
+						<div class="project-detail-card-heading">
+							<div>
+								<h2>작업 링크</h2>
+								<p>프로젝트 작업을 진행하는 외부 링크 바로가기를
+									만듭니다.</p>
+							</div>
+							<strong
+								class="project-detail-count"
+								th:text="${project.links != null ? project.links.size() : 0} + '개'"
+								>0개</strong
+							>
+						</div>
+						<div
+							class="project-detail-link-list"
+							th:if="${project.links != null and !project.links.isEmpty()}"
+						>
+							<a
+								class="project-detail-link-row"
+								th:each="link, linkStat : ${project.links}"
+								th:href="${link.url}"
+								target="_blank"
+								rel="noopener"
+							>
+								<span class="project-detail-icon-link" aria-hidden="true"></span>
+								<span>
+									<strong th:text="${link.label}">GitHub 저장소</strong>
+									<small th:text="${link.url}">https://github.com</small>
+								</span>
+							</a>
+						</div>
+						<p
+							class="project-detail-empty"
+							th:if="${project.links == null or project.links.isEmpty()}"
+						>
+							GitHub, Figma 같은 작업 링크를 추가하세요.
+						</p>
+						<form
+							class="project-detail-form"
+							th:if="${projectEditable}"
+							th:action="@{/project/{id}/links(id=${project.id})}"
+							method="post"
+						>
+							<input class="input" type="text" name="label" placeholder="링크 이름: GitHub" required />
+							<input
+								class="input"
+								type="url"
+								name="url"
+								placeholder="https://github.com/team/repo"
+								required
+							/>
+							<button type="submit" class="btn btn-primary">링크 추가</button>
+						</form>
+					</article>
+
+					<article class="card project-detail-card" th:if="${projectOwner}">
+						<div class="project-detail-card-heading">
+							<div>
+								<h2>상태 관리</h2>
+								<p>프로젝트 상태와 위험 작업을 관리합니다.</p>
+							</div>
+						</div>
+						<form
+							class="project-detail-form"
+							th:action="@{/project/{projectId}/status(projectId=${project.id})}"
+							method="post"
+							onsubmit="return confirmProjectStatusChange();"
+						>
+							<select id="projectStatusSelect" class="input" name="status" required>
+								<option
+									th:each="status : ${projectStatuses}"
+									th:value="${status}"
+									th:text="${status.label}"
+									th:selected="${status == project.status}"
+								>
+									진행중
+								</option>
+							</select>
+							<button type="submit" class="btn btn-primary">상태 변경</button>
+						</form>
+						<form
+							class="project-detail-form compact"
+							th:action="@{/project/{projectId}/delete(projectId=${project.id})}"
+							method="post"
+							onsubmit="return confirm('프로젝트를 삭제하시겠습니까?');"
+						>
+							<button type="submit" class="btn btn-danger project-detail-wide-button">
+								프로젝트 삭제
+							</button>
+						</form>
+					</article>
+				</section>
+			</div>
+		</main>
+		<script th:replace="~{fragments/project_layout :: statusScript}"></script>
+	</body>
+</html>

--- a/src/main/resources/templates/project_settings.html
+++ b/src/main/resources/templates/project_settings.html
@@ -33,7 +33,7 @@
 								target="_blank"
 								rel="noopener"
 							>
-								<span class="project-detail-icon-link" aria-hidden="true"></span>
+								<span class="project-detail-icon-link icon icon-external-link" aria-hidden="true"></span>
 								<span>
 									<strong th:text="${link.label}">GitHub 저장소</strong>
 									<small th:text="${link.url}">https://github.com</small>

--- a/src/main/resources/templates/project_task.html
+++ b/src/main/resources/templates/project_task.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org">
+	<head th:replace="~{fragments/project_layout :: head}"></head>
+
+	<body class="has-sidebar">
+		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<main>
+			<div class="project-detail-page">
+				<div th:replace="~{fragments/project_layout :: header('task')}"></div>
+				<section class="project-detail-panel active">
+					<article class="card project-detail-card" id="project-tasks">
+						<div class="project-detail-card-heading">
+							<div>
+								<h2>할 일</h2>
+								<p>태스크를 추가하고 완료 상태를 관리하세요.</p>
+							</div>
+							<span class="project-detail-active-count">
+								<span aria-hidden="true"></span>
+								<span th:text="${incompleteTaskCount} + '개의 활성 작업'">0개의 활성 작업</span>
+							</span>
+						</div>
+
+						<form
+							class="project-detail-task-form"
+							th:if="${projectEditable}"
+							th:action="@{/project/{id}/tasks(id=${project.id})}"
+							method="post"
+						>
+							<input class="input" type="text" name="title" placeholder="태스크 제목" required />
+							<select class="input" name="assigneeId" required>
+								<option value="">담당자 선택</option>
+								<option
+									th:each="projectMember : ${project.members}"
+									th:value="${projectMember.member.id}"
+									th:text="${projectMember.member.name}"
+								>
+									팀원 이름
+								</option>
+							</select>
+							<button type="submit" class="btn btn-primary">태스크 추가</button>
+						</form>
+
+						<div
+							class="project-detail-task-board"
+							th:if="${tasks != null and !tasks.isEmpty()}"
+						>
+							<div class="project-detail-task-lane project-detail-task-lane-progress">
+								<div class="project-detail-lane-title">
+									<strong>진행 중</strong>
+									<span th:text="${incompleteTaskCount}">1</span>
+								</div>
+								<div
+									class="project-detail-task-card"
+									th:each="task : ${tasks}"
+									th:if="${!task.completed}"
+								>
+									<div class="project-detail-task-content">
+										<span class="chip chip-purple">태스크</span>
+										<strong th:text="${task.title}">태스크 제목</strong>
+										<p>
+											담당자:
+											<span th:text="${task.assignee.name}">담당자 이름</span>
+										</p>
+									</div>
+									<form
+										th:if="${projectEditable}"
+										th:action="@{/project/{projectId}/tasks/{taskId}/toggle(projectId=${project.id}, taskId=${task.id})}"
+										method="post"
+										class="project-detail-check-form"
+									>
+										<label class="project-detail-check">
+											<input
+												type="checkbox"
+												th:checked="${task.completed}"
+												onchange="this.form.submit()"
+											/>
+											<span>완료</span>
+										</label>
+									</form>
+								</div>
+							</div>
+
+							<div class="project-detail-task-lane project-detail-task-lane-done">
+								<div class="project-detail-lane-title">
+									<strong>완료</strong>
+									<span th:text="${myCompletedTaskCount}">4</span>
+								</div>
+								<div
+									class="project-detail-task-card completed"
+									th:each="task : ${tasks}"
+									th:if="${task.completed}"
+								>
+									<div class="project-detail-task-content">
+										<span class="chip chip-green">완료됨</span>
+										<strong th:text="${task.title}">완료한 태스크</strong>
+										<p>
+											담당자:
+											<span th:text="${task.assignee.name}">담당자 이름</span>
+										</p>
+									</div>
+									<form
+										th:if="${projectEditable}"
+										th:action="@{/project/{projectId}/tasks/{taskId}/toggle(projectId=${project.id}, taskId=${task.id})}"
+										method="post"
+										class="project-detail-check-form"
+									>
+										<label class="project-detail-check">
+											<input
+												type="checkbox"
+												th:checked="${task.completed}"
+												onchange="this.form.submit()"
+											/>
+											<span>완료</span>
+										</label>
+									</form>
+								</div>
+							</div>
+						</div>
+						<p class="project-detail-empty" th:if="${tasks == null or tasks.isEmpty()}">
+							아직 등록된 태스크가 없습니다.
+						</p>
+					</article>
+				</section>
+			</div>
+		</main>
+	</body>
+</html>

--- a/src/main/resources/templates/project_task.html
+++ b/src/main/resources/templates/project_task.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 	<head th:replace="~{fragments/project_layout :: head}"></head>
 
-	<body class="has-sidebar">
+	<body>
 		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
 		<main>
 			<div class="project-detail-page">

--- a/src/main/resources/templates/project_task.html
+++ b/src/main/resources/templates/project_task.html
@@ -8,6 +8,43 @@
 			<div class="project-detail-page">
 				<div th:replace="~{fragments/project_layout :: header('task')}"></div>
 				<section class="project-detail-panel active">
+					<article class="card project-detail-card">
+						<div class="project-detail-card-heading">
+							<div>
+								<h2>스프린트 개요</h2>
+								<p>현재 태스크 진행 상황</p>
+							</div>
+						</div>
+
+						<div class="project-detail-progress-list">
+							<div class="project-detail-progress-row">
+								<div class="project-detail-progress-label">
+									<strong>나의 진행도</strong>
+									<span th:text="${myTaskCompletionRate} + '%'">85%</span>
+								</div>
+								<div class="progress">
+									<div
+										class="progress-fill"
+										th:style="'width: ' + ${myTaskCompletionRate} + '%'"
+									></div>
+								</div>
+							</div>
+
+							<div class="project-detail-progress-row">
+								<div class="project-detail-progress-label">
+									<strong>팀 평균 진행도</strong>
+									<span th:text="${myTaskCompletionRate} + '%'">68%</span>
+								</div>
+								<div class="progress">
+									<div
+										class="progress-fill"
+										th:style="'width: ' + ${myTaskCompletionRate} + '%'"
+									></div>
+								</div>
+							</div>
+						</div>
+					</article>
+
 					<article class="card project-detail-card" id="project-tasks">
 						<div class="project-detail-card-heading">
 							<div>

--- a/src/main/resources/templates/schedule.html
+++ b/src/main/resources/templates/schedule.html
@@ -51,7 +51,7 @@
 								th:href="@{/schedule(date=${weekStart.minusWeeks(1)})}"
 							>
 								<span
-									class="schedule-icon schedule-icon-chevron-left"
+									class="schedule-icon icon icon-chevron-left"
 									aria-hidden="true"
 								></span>
 							</a>
@@ -67,7 +67,7 @@
 								th:href="@{/schedule(date=${weekStart.plusWeeks(1)})}"
 							>
 								<span
-									class="schedule-icon schedule-icon-chevron-right"
+									class="schedule-icon icon icon-chevron-right"
 									aria-hidden="true"
 								></span>
 							</a>
@@ -84,7 +84,7 @@
 							"
 						>
 							<span
-								class="schedule-icon schedule-icon-plus"
+								class="schedule-icon icon icon-plus"
 								aria-hidden="true"
 							></span>
 							일정 추가
@@ -255,7 +255,7 @@
 							"
 						>
 							<span
-								class="schedule-icon schedule-icon-x"
+								class="schedule-icon icon icon-x"
 								aria-hidden="true"
 							></span>
 						</button>
@@ -472,7 +472,7 @@
 							"
 						>
 							<span
-								class="schedule-icon schedule-icon-x"
+								class="schedule-icon icon icon-x"
 								aria-hidden="true"
 							></span>
 						</button>


### PR DESCRIPTION
 * 개요, 할일, 일정, 팀, 설정 탭으로 페이지 분리
 * common.css 기반으로 피그마 디자인 반영
 * 오직 프론트엔드 부분만 수정함. 백엔드 도메인 로직은 수정하지 않았으므로 필요시 구현 필요
 * 각 탭 페이지는 이전의 카드 형태를 전체화면으로 키운 형태일 뿐이라 어색할 수 있으며, 절대로 완벽한 상태라고 말할 수 없음. 각 탭 담당에서 적절한 형태로 개선 필요.
   * 이 브랜치를 기반으로 브랜치를 만들어 (기존 브랜치에서는 이 브랜치로 rebase) 작업 요망
 * 기존 작업 영역과 겹칠 수 있으므로 전원 승인 시에만 main 병합 예정
 * AI를 통해 작업했으므로, 이전 작업 내용을 망칠 가능성이 있을 수 있음. 이전 작업 부분이 누락되지 않았는지 검토 필요
 
 
<img width="2475" height="1651" alt="image" src="https://github.com/user-attachments/assets/62c19f5b-d44a-40a4-9618-0eedcba60e1c" />
<img width="2475" height="1401" alt="image" src="https://github.com/user-attachments/assets/941966a6-9418-4001-9cb1-6a617e0bb0ed" />
<img width="2498" height="1371" alt="image" src="https://github.com/user-attachments/assets/62882542-dd69-4bc9-865d-f747a7cdc9e4" />
<img width="2498" height="1371" alt="image" src="https://github.com/user-attachments/assets/8a5d5a28-4a6b-4d90-bb3e-634f52aa292f" />
